### PR TITLE
Force CMake>=3.5 when building cuDNN FE

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,7 +110,8 @@ RUN git clone -b release-v3 https://github.com/NVIDIA/NVTX.git && cd NVTX/python
     python3 -m pip install --no-build-isolation .
 
 # Install cuDNN FE
-RUN apt install -y cudnn && export CUDNN_INCLUDE_DIR=/usr/include && \
+RUN apt install -y cudnn && \
+    CUDNN_INCLUDE_DIR=/usr/include CMAKE_POLICY_VERSION_MINIMUM=3.5 \
     python3 -m pip install git+https://github.com/NVIDIA/cudnn-frontend.git
 
 # Install CUDA-Python


### PR DESCRIPTION
cuDNN FrontEnd depends on DLPack 0.8, which uses CMake 3.2.

CMake 4.0 dropped support for CMake<3.5. This shouldn't break anything in DLPack as a similar fix was done recently upstream[^1]. This fix might not be necessary in the future if cuDNN FE switches to a version of DLPack supporting newer CMake.

[^1]: https://github.com/dmlc/dlpack/pull/163